### PR TITLE
Move configs to config module & Allocate Initial Rewards in Initializer

### DIFF
--- a/apus_token/config.lua
+++ b/apus_token/config.lua
@@ -1,0 +1,44 @@
+-- AO Addresses
+AO_MINT_PROCESS = "LPK-D_3gZkXtia6ywwU1wRwgFOZ-eLFRMP9pfAFRfuw"
+APUS_STATS_PROCESS = "zmr4sqL_fQjjvHoUJDkT8eqCiLFEM3RV5M96Wd59ffU"
+
+-- Minting cycle interval in seconds
+MINT_COOL_DOWN = 300
+
+-- Tokenomics
+Name = "Apus"
+Ticker = "Apus"
+Logo = "SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY"
+
+-- T0 token receivers
+T0_ALLOCATION = {
+  -- 1% to liquidity
+  { Author = "Liquidity_Address",      Amount = "10000000000000000000" },
+
+  -- 5% to pool bootstrap
+  { Author = "Pool_Bootstrap_Address", Amount = "50000000000000000000" },
+
+  -- 2% to contributors
+  { Author = "Contributor_1",          Amount = "1000000000000000000" },
+  { Author = "Contributor_2",          Amount = "1000000000000000000" },
+  { Author = "Contributor_3",          Amount = "1000000000000000000" },
+  { Author = "Contributor_4",          Amount = "1000000000000000000" },
+  { Author = "Contributor_5",          Amount = "1000000000000000000" },
+  { Author = "Contributor_6",          Amount = "1000000000000000000" },
+  { Author = "Contributor_7",          Amount = "1000000000000000000" },
+  { Author = "Contributor_8",          Amount = "1000000000000000000" },
+  { Author = "Contributor_9",          Amount = "1000000000000000000" },
+  { Author = "Contributor_10",         Amount = "1000000000000000000" },
+  { Author = "Contributor_11",         Amount = "1000000000000000000" },
+  { Author = "Contributor_12",         Amount = "1000000000000000000" },
+  { Author = "Contributor_13",         Amount = "1000000000000000000" },
+  { Author = "Contributor_14",         Amount = "1000000000000000000" },
+  { Author = "Contributor_15",         Amount = "1000000000000000000" },
+  { Author = "Contributor_16",         Amount = "1000000000000000000" },
+  { Author = "Contributor_17",         Amount = "1000000000000000000" },
+  { Author = "Contributor_18",         Amount = "1000000000000000000" },
+  { Author = "Contributor_19",         Amount = "1000000000000000000" },
+  { Author = "Contributor_20",         Amount = "1000000000000000000" }
+}
+
+return {}

--- a/apus_token/main.lua
+++ b/apus_token/main.lua
@@ -22,8 +22,7 @@ Token = require('token')
 Allocator = require('allocator')
 Distributor = require('distributor')
 
-AO_MINT_PROCESS = "LPK-D_3gZkXtia6ywwU1wRwgFOZ-eLFRMP9pfAFRfuw"
-APUS_STATS_PROCESS = "zmr4sqL_fQjjvHoUJDkT8eqCiLFEM3RV5M96Wd59ffU"
+require('config')
 
 -- Function to verify if a message is a mint report from AO Mint Process
 local function isMintReportFromAOMint(msg)
@@ -121,4 +120,20 @@ Initialized = Initialized or false
   print("Initializing ...")
   -- Subscribe Mint Report From AO Mint Process
   Send({ Target = AO_MINT_PROCESS, Action = "Recipient.Subscribe-Report", ["Report-To"] = ao.id })
+
+  -- check if the sum is 8% of the total supply
+  local sum = Utils.reduce(function(acc, value)
+    return BintUtils.add(acc, value.Amount)
+  end, "0", T0_ALLOCATION)
+  assert(sum == "80000000000000000000")
+
+  -- set balance for each user
+  Utils.map(function(r)
+    Balances[r.Author] = BintUtils.add(Balances[r.Author] or "0", r.Amount)
+  end, T0_ALLOCATION)
+
+  -- set minted supply
+  MintedSupply = Utils.reduce(function(acc, value)
+    return BintUtils.add(acc, value)
+  end, "0", Utils.values(Balances))
 end)()

--- a/apus_token/main.lua
+++ b/apus_token/main.lua
@@ -7,6 +7,9 @@ local Utils = require('.utils')
 local BintUtils = require('utils.bint_utils')
 local EthAddressUtils = require('utils.eth_address')
 
+-- Constants
+INITIAL_CAPITAL = "80000000000000000000" -- 80,000,000 tokens with denomination
+
 -- Initialize in-memory SQLite database or reuse existing one
 MintDb = MintDb or sqlite3.open_memory()
 
@@ -125,7 +128,7 @@ Initialized = Initialized or false
   local sum = Utils.reduce(function(acc, value)
     return BintUtils.add(acc, value.Amount)
   end, "0", T0_ALLOCATION)
-  assert(sum == "80000000000000000000")
+  assert(sum == INITIAL_CAPITAL)
 
   -- set balance for each user
   Utils.map(function(r)

--- a/apus_token/mint.lua
+++ b/apus_token/mint.lua
@@ -31,12 +31,10 @@ INTERVALS_PER_MONTH = math.floor(DAYS_PER_MONTH * 24 * 12 + 0.5)
 
 -- Circulating Supply Variables
 -- Initial minted supply in smallest denomination
-MintedSupply = MintedSupply or "80000000000000000000"
+MintedSupply = MintedSupply or "0"
 -- Number of times minting has occurred
 MintTimes = MintTimes or 1
 
--- Minting cycle interval in seconds
-MINT_COOL_DOWN = 300
 -- Timestamp of the last minting
 LastMintTime = LastMintTime or 0
 -- Current minting mode ("ON" or "OFF"), ON: auto-mint; OFF: manual-mint

--- a/apus_token/token.lua
+++ b/apus_token/token.lua
@@ -26,13 +26,9 @@ Variant = "0.0.3"
 -- token should be idempotent and not change previous state updates
 Denomination = Denomination or 12
 -- Initial balance for the process
-Balances = Balances or { [ao.id] = "80000000000000000000" }
+Balances = Balances or {}
 -- Total supply of tokens: 1_000_000_000 Apus Tokens; 1_000_000_000_000_000_000 with denomination
 TotalSupply = "1000000000000000000000"
-Name = "Apus"
-Ticker = "Apus"
--- @TODO: Logo
-Logo = Logo or "SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY"
 -- Flag indicating if transfer is enabled
 IsTNComing = IsTNComing or false
 

--- a/spec/mint_normal_spec.lua
+++ b/spec/mint_normal_spec.lua
@@ -12,6 +12,7 @@ Mint = nil
 Allocator = require('allocator')
 
 Balances = { ["ADDRESS_1"] = "80000000000000000000" }
+MintedSupply = "80000000000000000000"
 
 GetCurrentTime = function()
     return 112233
@@ -24,6 +25,8 @@ function TestMintNormal:setup()
     Deposits = require('dal.deposits').new(DbAdmin)
 
     Mint = require('mint')
+    require('config')
+    MODE = "ON"
 end
 
 function TestMintNormal:teardown()
@@ -43,7 +46,6 @@ function TestMintNormal:test_01_Basic()
     luaunit.assertNotNil(Deposits)
 
     luaunit.assertEquals(MINT_CAPACITY, "1000000000000000000000")
-    luaunit.assertEquals(ApusStatisticsProcess, "")
     -- luaunit.assertEquals(APUS_MINT_PCT_1, 194218390)
     -- luaunit.assertEquals(APUS_MINT_PCT_2, 164733613)
     luaunit.assertEquals(INTERVALS_PER_YEAR, 365.25 * 24 * 12)
@@ -128,8 +130,6 @@ function TestMintNormal:test_02_Insert()
     luaunit.assertEquals(Deposits:getByUser("0x0d386297c95C7e48db734E3Eb2F476CD73f92E59").Recipient, "")
     luaunit.assertEquals(Deposits:getByUser("0x7300782D46E385B1D0B4e831D48c4224F502ECb9").Recipient, "")
     luaunit.assertEquals(Deposits:getByUser("0x43C68e2C3Fc96b077d19e503a609a83Cb4D0c6fA").Recipient, "")
-
-    clear()
 end
 
 -- [[
@@ -210,7 +210,7 @@ function TestMintNormal:test_03_AllocateWithoutBinding()
     luaunit.assertEquals(Deposits:getByUser("0x43C68e2C3Fc96b077d19e503a609a83Cb4D0c6fA").Recipient, "")
 
     local beforeSupply = MintedSupply
-    Mint.mint({ Timestamp = 300 })
+    Mint.mint({ Timestamp = 300000 })
     local afterSupply = MintedSupply
     luaunit.assertEquals(BintUtils.subtract(afterSupply, beforeSupply), "0")
     luaunit.assertIsNil(Balances["0x6DCeB0F7Dd6bED4fF190D8cA74F67973C280f4B4"])
@@ -219,8 +219,6 @@ function TestMintNormal:test_03_AllocateWithoutBinding()
     luaunit.assertIsNil(Balances["0x0d386297c95C7e48db734E3Eb2F476CD73f92E59"])
     luaunit.assertIsNil(Balances["0x7300782D46E385B1D0B4e831D48c4224F502ECb9"])
     luaunit.assertIsNil(Balances["0x43C68e2C3Fc96b077d19e503a609a83Cb4D0c6fA"])
-
-    clear()
 end
 
 -- [[
@@ -317,7 +315,7 @@ function TestMintNormal:test_04_AllocateWithUsersBinded()
     local releaseAmount = Mint.currentMintAmount()
     local beforeSupply = MintedSupply
 
-    Mint.mint({ Timestamp = 300 })
+    Mint.mint({ Timestamp = 300000 })
     luaunit.assertIsTrue(BintUtils.subtract(MintedSupply, beforeSupply) > bint(0))
     -- luaunit.assertEquals(MintedSupply, "0")
     -- luaunit.assertEquals(Deposits:getByUser("0x6DCeB0F7Dd6bED4fF190D8cA74F67973C280f4B4").Mint, "0")
@@ -328,14 +326,13 @@ function TestMintNormal:test_04_AllocateWithUsersBinded()
     -- luaunit.assertEquals(Deposits:getByUser("0x43C68e2C3Fc96b077d19e503a609a83Cb4D0c6fA").Mint, "0")
 
     -- print(Balances)
-    clear()
 end
 
 function TestMintNormal:test_05_MintFailWontBlock()
     local res
-    res = Mint.mint({ Timestamp = 300 })
+    res = Mint.mint({ Timestamp = 300000 })
     luaunit.assertEquals(res, "No users in the pool.")
-    res = Mint.mint({ Timestamp = 300 })
+    res = Mint.mint({ Timestamp = 300000 })
     luaunit.assertEquals(res, "No users in the pool.")
 end
 
@@ -430,14 +427,13 @@ function TestMintNormal:test_06_MintSuccessWontBlock()
     local releaseAmount = Mint.currentMintAmount()
     local beforeSupply = MintedSupply
 
-    res = Mint.mint({ Timestamp = 300 })
+    res = Mint.mint({ Timestamp = 300000 })
     luaunit.assertIsTrue(BintUtils.subtract(MintedSupply, beforeSupply) > bint(0))
     luaunit.assertEquals(res, "OK")
-    res = Mint.mint({ Timestamp = 550 })
+    res = Mint.mint({ Timestamp = 550000 })
     print(LastMintTime)
     luaunit.assertEquals(res, "Not cool down yet")
 end
-
 
 function TestMintNormal:test_07_Mode()
     local mintReportList = {}
@@ -461,7 +457,7 @@ function TestMintNormal:test_07_Mode()
 
     MODE = "OFF"
 
-    local ret = Mint.mint({ Timestamp = 300, Action = "Cron" })
+    local ret = Mint.mint({ Timestamp = 300000, Action = "Cron" })
     luaunit.assertEquals(MintedSupply, beforeSupply)
     luaunit.assertEquals(ret, "Not Minting by CRON untils MODE is set to ON")
 end


### PR DESCRIPTION
1. MOVE  config variables to isolate the config module
2. Allocate t0 rewards to users in the initializer.
3. fix mint_normal_spec test