### PR TITLE
add StartMintTime

### DIFF
--- a/apus_token/config.lua
+++ b/apus_token/config.lua
@@ -8,7 +8,7 @@ AO_RECEIVER = ao.id
 MINT_COOL_DOWN = 300
 
 -- The moment the process starts to process with mint reports
-StartMintTime = 0
+StartMintTime = StartMintTime or 0
 
 -- Tokenomics
 Name = "Apus"

--- a/apus_token/config.lua
+++ b/apus_token/config.lua
@@ -7,6 +7,9 @@ AO_RECEIVER = ao.id
 -- Minting cycle interval in seconds
 MINT_COOL_DOWN = 300
 
+-- The moment the process starts to process with mint reports
+StartMintTime = 0
+
 -- Tokenomics
 Name = "Apus"
 Ticker = "Apus"

--- a/apus_token/main.lua
+++ b/apus_token/main.lua
@@ -32,10 +32,6 @@ local function isMintReportFromAOMint(msg)
   return msg.Action == "Report.Mint" and msg.From == AO_MINT_PROCESS
 end
 
-local function isMintTrigger(msg)
-  return msg.Action == "Mint.Mint" and msg.From == APUS_MINT_TRIGGER
-end
-
 -- Handler for AO Mint Report
 Handlers.add("AO-Mint-Report", isMintReportFromAOMint, function(msg)
   if msg.Timestamp // 1000 <= StartMintTime then
@@ -54,7 +50,7 @@ Handlers.add("AO-Mint-Report", isMintReportFromAOMint, function(msg)
 end)
 
 -- Cron job handler to trigger minting process (MODE = "ON")
-Handlers.add("Mint.Mint", isMintTrigger, Mint.mint)
+Handlers.add("Mint.Mint", "Cron", Mint.mint)
 
 -- Handler for Mint Backup process (MODE = "OFF")
 Handlers.add("Mint.Backup", "Mint.Backup", Mint.mintBackUp)

--- a/apus_token/main.lua
+++ b/apus_token/main.lua
@@ -36,11 +36,10 @@ local function isMintTrigger(msg)
   return msg.Action == "Mint.Mint" and msg.From == APUS_MINT_TRIGGER
 end
 
-AllowMintReport = AllowMintReport or false
 -- Handler for AO Mint Report
 Handlers.add("AO-Mint-Report", isMintReportFromAOMint, function(msg)
-  if not AllowMintReport then
-    print("Not receive mint reports yet.")
+  if msg.Timestamp // 1000 <= StartMintTime then
+    print("Not receiving messages until " .. os.date("%Y-%m-%d %H:%M:%S", StartMintTime) .. "(UTC)")
     return
   end
   -- Filter reports where the recipient matches the current process ID

--- a/apus_token/mint.lua
+++ b/apus_token/mint.lua
@@ -100,9 +100,9 @@ Mint.mint = function(msg)
         end
 
         -- If the action is triggered by Cron and the mode is OFF, do not proceed with minting
-        if msg.Action == "Cron" and MODE == "OFF" then
-            print("Not Minting by CRON untils MODE is set to ON")
-            return "Not Minting by CRON untils MODE is set to ON"
+        if msg.Action == "Mint.Mint" and MODE == "OFF" then
+            print("Not Minting by APUS_MINT_TRIGGER untils MODE is set to ON")
+            return "Not Minting by APUS_MINT_TRIGGER untils MODE is set to ON"
         end
 
         -- Calculate how many times minting should occur based on the cooldown period

--- a/apus_token/mint.lua
+++ b/apus_token/mint.lua
@@ -101,8 +101,8 @@ Mint.mint = function(msg)
 
         -- If the action is triggered by Cron and the mode is OFF, do not proceed with minting
         if msg.Action == "Cron" and MODE == "OFF" then
-            print("Not Minting by Cron untils MODE is set to ON")
-            return "Not Minting by Cron untils MODE is set to ON"
+            print("Not Minting by CRON untils MODE is set to ON")
+            return "Not Minting by CRON untils MODE is set to ON"
         end
 
         -- Calculate how many times minting should occur based on the cooldown period

--- a/apus_token/mint.lua
+++ b/apus_token/mint.lua
@@ -100,9 +100,9 @@ Mint.mint = function(msg)
         end
 
         -- If the action is triggered by Cron and the mode is OFF, do not proceed with minting
-        if msg.Action == "Mint.Mint" and MODE == "OFF" then
-            print("Not Minting by APUS_MINT_TRIGGER untils MODE is set to ON")
-            return "Not Minting by APUS_MINT_TRIGGER untils MODE is set to ON"
+        if msg.Action == "Cron" and MODE == "OFF" then
+            print("Not Minting by Cron untils MODE is set to ON")
+            return "Not Minting by Cron untils MODE is set to ON"
         end
 
         -- Calculate how many times minting should occur based on the cooldown period

--- a/scripts/cmd.js
+++ b/scripts/cmd.js
@@ -89,6 +89,11 @@ const deployCommand = {
         type: 'string',
         default: "test"
       })
+      .option('allowMint', {
+        description: 'timestamp that the process will start to process with mint reports',
+        type: 'number',
+        demandOption: true,
+      })
   },
   handler: (argv) => {
     deploy(argv)
@@ -107,8 +112,7 @@ const subscribeCommand = {
       })
       .option('reportTo', {
         describe: 'Which address the report is sent to',
-        type: 'string',
-        demandOption: true
+        type: 'string'
       })
       .option('env', {
         description: 'production or test',

--- a/scripts/cmd.js
+++ b/scripts/cmd.js
@@ -8,6 +8,7 @@ import subscribe from './sub/subscribe.mjs';
 import { testAllocation } from './sub/test_allocation.mjs';
 import generateTestAddresses from './sub/generate_ether_accounts.mjs';
 import allowMintReport from './sub/allow_mint_report.mjs';
+import sendMessageToToken from './sub/send_message_to_token.mjs';
 
 
 const cmd = yargs(hideBin(process.argv));
@@ -160,6 +161,22 @@ const allowMintReportCommand = {
   }
 }
 
+const sendMessageToTokenCommand = {
+  command: 'send_message_to_token <message>',
+  describe: "send message to token.",
+  builder: (yargs) => {
+    return yargs
+      .positional('message', {
+        describe: 'message sent to the process',
+        type: 'string',
+        demandOption: true
+      })
+  },
+  handler: (argv) => {
+    sendMessageToToken(argv)
+  }
+}
+
 
 // 定义子命令
 cmd
@@ -170,6 +187,7 @@ cmd
   .command(testAllocationCommand)
   .command(generateEtherAccountsCommand)
   .command(allowMintReportCommand)
+  .command(sendMessageToTokenCommand)
   .demandCommand(1, chalk.red('You must provide at least one command.')) // 必须输入命令
   .fail((msg, err, yargs) => {
     if (err) {

--- a/scripts/sub/deploy.mjs
+++ b/scripts/sub/deploy.mjs
@@ -531,7 +531,7 @@ AO_RECEIVER = "${AO_RECEIVER}"
 MINT_COOL_DOWN = 300
 
 -- The moment the process starts to process with mint reports
-StartMintTime = ${START_MINT_TIME}
+StartMintTime = StartMintTime or ${START_MINT_TIME}
 
 --Tokenomics
 Name = "${conf.APUS_TOKEN_NAME}"

--- a/scripts/sub/deploy.mjs
+++ b/scripts/sub/deploy.mjs
@@ -13,6 +13,7 @@ dotenv.config()
 let ConfigPath = 'scripts/tmp/conf'
 let AO_MINT_PROCESS = ''
 let AO_RECEIVER = process.env.AO_RECEIVER || 'gd66FHg7Q1nMYm25lRzXuUGZv5jw5d0bKaPhHp9mkBI'
+let START_MINT_TIME = 0
 
 function _exploreNodes(node, cwd) {
   if (!fs.existsSync(node.path)) return []
@@ -428,6 +429,7 @@ async function prepareConfig(argv) {
   }
 
   try {
+    START_MINT_TIME = argv.allowMint
     if (argv.config) {
       ConfigPath = argv.config
       if (!fs.existsSync(ConfigPath)) {
@@ -527,6 +529,9 @@ AO_RECEIVER = "${AO_RECEIVER}"
 
 --Minting cycle interval in seconds
 MINT_COOL_DOWN = 300
+
+-- The moment the process starts to process with mint reports
+StartMintTime = ${START_MINT_TIME}
 
 --Tokenomics
 Name = "${conf.APUS_TOKEN_NAME}"
@@ -717,6 +722,9 @@ async function afterCheck(argv) {
     { process: apusTokenProcess, line: "MINT_COOL_DOWN", assertion: 300 }
   )
   await sendEvalAndCheckRes(
+    { process: apusTokenProcess, line: "StartMintTime", assertion: START_MINT_TIME }
+  )
+  await sendEvalAndCheckRes(
     { process: apusTokenProcess, line: "Name", assertion: conf.APUS_TOKEN_NAME }
   )
   await sendEvalAndCheckRes(
@@ -814,11 +822,16 @@ async function afterCheck(argv) {
   )
 }
 
-async function showResult() {
+async function showResult(argv) {
   simpleSuccess(`Complete!\n`)
   console.log(`Apus Token Process:\t${_readRuntime().APUS_TOKEN_PROCESS_ID}`)
   console.log(`Apus Stats Process:\t${_readRuntime().APUS_STATS_PROCESS_ID}`)
-  console.log(`Test link:\thttps://test.apus.network/#/mint?apus_process=${_readRuntime().APUS_TOKEN_PROCESS_ID}&mirror_process=${_readRuntime().APUS_STATS_PROCESS_ID}&tge_time=2024-12-13T08:00:00Z`)
+  console.log("\n\n")
+  console.log(`First, you can run script:\n\nnpm run helper -- subscribe --keyFile=[your_key_file] --env=${argv.env}\n\nto subscribe for the new process, it read from scripts/tmp/conf/runtime.yml by default.`)
+  console.log("\n\n")
+  console.log(`Go to page\nhttps://www.ao.link/#/token/${_readRuntime().APUS_TOKEN_PROCESS_ID}?tab=chart\ncheck name, logo, ticker and initial allocation.`)
+  console.log("\n\n")
+  console.log(`Entity page: https://www.ao.link/#/entity/${_readRuntime().APUS_TOKEN_PROCESS_ID}`)
 }
 
 export default async function deploy(argv) {

--- a/scripts/sub/send_message_to_token.mjs
+++ b/scripts/sub/send_message_to_token.mjs
@@ -1,0 +1,54 @@
+import { connect, createDataItemSigner, dryrun, results } from "@permaweb/aoconnect"
+import Arweave from 'arweave'
+import { asyncWithBreathingLog } from "../lib/async_with_log.mjs"
+import fs from 'fs'
+import path from 'path'
+import yaml from 'js-yaml'
+import os from 'os'
+
+let ConfigPath = 'scripts/tmp/conf'
+
+function _readRuntime() {
+  if (!fs.existsSync(path.join(ConfigPath, "runtime.yml"))) {
+    fs.writeFileSync(path.join(ConfigPath, "runtime.yml"), '')
+  }
+  return yaml.load(fs.readFileSync(path.join(ConfigPath, "runtime.yml"), 'utf-8'))
+}
+
+async function _getAOWallet() {
+  const _arweave = Arweave.init()
+  const jwk = JSON.parse(fs.readFileSync(path.resolve(process.env.OWNER_JSON_LOCATION || `${os.homedir()}/.aos.json`), 'utf-8'))
+  const address = await _arweave.wallets.jwkToAddress(jwk)
+  return { jwk, address }
+}
+
+async function _sendMessageAndGetResult(process, data, tags) {
+  const { jwk, address } = await _getAOWallet()
+  const signer = createDataItemSigner(jwk)
+  const message = await connect().message({
+    process,
+    signer,
+    tags: tags || [
+      {
+        name: 'Action', value: 'Eval'
+      }
+    ],
+    data
+  })
+  const result = await connect().result({
+    process,
+    message
+  })
+  return result
+}
+
+export default async function sendMessageToToken(argv) {
+  try {
+    const message = argv.message
+    const res = await asyncWithBreathingLog(_sendMessageAndGetResult, [_readRuntime().APUS_TOKEN_PROCESS_ID, message], `Send message \`${message}\` to process ${_readRuntime().APUS_TOKEN_PROCESS_ID}`)
+
+    console.log(res)
+  } catch (err) {
+    console.log(err)
+  }
+}

--- a/scripts/sub/subscribe.mjs
+++ b/scripts/sub/subscribe.mjs
@@ -8,6 +8,15 @@ let JWK = ''
 let WALLET = ''
 let AO_MINT_PROCESS = ''
 
+
+
+function _readRuntime() {
+  if (!fs.existsSync(path.join(ConfigPath, "runtime.yml"))) {
+    fs.writeFileSync(path.join(ConfigPath, "runtime.yml"), '')
+  }
+  return yaml.load(fs.readFileSync(path.join(ConfigPath, "runtime.yml"), 'utf-8'))
+}
+
 async function _getAOWallet(keyFile) {
   const _arweave = Arweave.init()
   const jwk = keyFile ? JSON.parse(fs.readFileSync(keyFile, 'utf-8')) : JWK
@@ -37,10 +46,11 @@ async function _sendMessageAndGetResult(process, data, tags) {
 
 async function sendSubscribeAndCheckRes(argv) {
   try {
+    const reportTo = argv.reportTo ?? _readRuntime().APUS_TOKEN_PROCESS_ID
     const res = await asyncWithBreathingLog(_sendMessageAndGetResult, [AO_MINT_PROCESS, "", [
       { name: 'Action', value: "Report.Subscribe" },
-      { name: 'Report-To', value: argv.reportTo }
-    ]], `Send subscribe message to ${AO_MINT_PROCESS}, report-to:${argv.reportTo}`)
+      { name: 'Report-To', value: reportTo }
+    ]], `Send subscribe message to ${AO_MINT_PROCESS}, report-to:${reportTo}`)
     if (res.Error) {
       throw Error('Message error')
     }


### PR DESCRIPTION
1. Keep tracking new variables in `apus_token/config.lua`
2. Remove `AllowMintReport`, use StartMintTime to limit mint reports.
3. Fix msg.Action in Mint.mint function, so that MODE can work
4. Add allowMint for deploy script, and set reportTo unnecessary parameter in subscribe, it read runtime.yml by default.
5. Add more outputs for deploy script, such as the process token page and entity page.