### PR TITLE
Separate T0 Allocation to another file & Polish up logs

### DIFF
--- a/apus_token/init_t0_allocation.lua
+++ b/apus_token/init_t0_allocation.lua
@@ -1,0 +1,37 @@
+-- ============================================================
+-- WARNING: DO NOT MODIFY THIS FILE AFTER INITIAL DEPLOYMENT!
+--
+-- This file is designed to be used only once during the
+-- initialization process. Any modification to this file
+-- may lead to being executed again, which can
+-- cause Token BROKEN.
+-- ============================================================
+local Utils = require('.utils')
+local BintUtils = require('utils.bint_utils')
+
+local Logger = require('utils.log')
+
+-- If T0 allocation is done
+T0Allocated = T0Allocated or false
+
+-- This function is used for allocating APUS tokens to T0 users.
+function T0Allocate()
+  if not T0Allocated then
+    T0Allocated = true
+    local beforeSupply = MintedSupply
+    -- set balance for each user
+    Utils.map(function(r)
+      Balances[r.Author] = BintUtils.add(Balances[r.Author] or "0", r.Amount)
+    end, T0_ALLOCATION)
+
+    -- set minted supply
+    MintedSupply = Utils.reduce(function(acc, value)
+      return BintUtils.add(acc, value)
+    end, "0", Utils.values(Balances))
+
+    Logger.info(string.format('Allocated %s to %d users, current minted supply: %s',
+      BintUtils.subtract(MintedSupply, beforeSupply), #T0_ALLOCATION, MintedSupply))
+  end
+end
+
+return T0Allocate

--- a/apus_token/mint.lua
+++ b/apus_token/mint.lua
@@ -51,7 +51,7 @@ LastMintTime = LastMintTime or 0
 ]]
 Mint.batchUpdate = function(mintReportList)
     -- Iterate over each mint report and update the corresponding user's mint information
-    Logger.info('Receive mint reports, add mint value for ' .. #mintReportList .. ' user(s).')
+    Logger.info('Receive mint reports: ' .. #mintReportList .. ' user(s).')
     Utils.map(function(mintReport)
         Deposits:updateMintForUser(mintReport.User, mintReport.Mint)
     end, mintReportList)

--- a/apus_token/token.lua
+++ b/apus_token/token.lua
@@ -43,7 +43,6 @@ IsTNComing = IsTNComing or false
    ]]
 --
 Token.info = function(msg)
-    print("Return Info")
     Send({
         Target = msg.From,
         Name = Name,

--- a/scripts/sub/check_after_deploy.mjs
+++ b/scripts/sub/check_after_deploy.mjs
@@ -177,7 +177,7 @@ async function sendDryRunAndCheckRes({ process, line, assertion, tags, checking 
         throw Error(`${checkingName}, actual: ${res.Output.data}, ${assertion}`)
       }
     } else if (typeof assertion == 'object') {
-      if (!deepEqual(assertion, JSON.parse(ret))) {
+      if (!containsSubset(JSON.parse(ret), assertion)) {
         throw Error(`${checkingName}`)
       }
     } else if (typeof assertion == 'boolean') {
@@ -416,6 +416,25 @@ async function afterCheck(argv) {
   await sendDryRunAndCheckRes({
     process: apusTokenProcess, line: `Token.mintedSupply`, assertion: "0", tags: _getTagsFromObj({
       Action: 'Minted-Supply'
+    })
+  })
+
+  await sendDryRunAndCheckRes({
+    process: apusTokenProcess, line: `Metrics`, assertion: {
+      AO_MINT_PROCESS: AO_MINT_PROCESS,
+      T0Allocated: false,
+      APUS_STATS_PROCESS: _readRuntime().APUS_STATS_PROCESS_ID,
+      AO_RECEIVER: AO_RECEIVER,
+      LastMintTime: 0,
+      IsTNComing: false,
+      MintTimes: 1,
+      MintedSupply: '0',
+      Initialized: true,
+      MODE: 'ON',
+      LogLevel: 'trace',
+      MINT_COOL_DOWN: 300
+    }, tags: _getTagsFromObj({
+      Action: 'Metrics'
     })
   })
 }

--- a/scripts/sub/check_after_deploy.mjs
+++ b/scripts/sub/check_after_deploy.mjs
@@ -10,7 +10,7 @@ import { containsSubset } from '../lib/obj_contain.mjs'
 
 let ConfigPath = 'scripts/tmp/conf'
 let AO_MINT_PROCESS = ''
-let AO_RECEIVER = process.env.AO_RECEIVER || 'gd66FHg7Q1nMYm25lRzXuUGZv5jw5d0bKaPhHp9mkBI'
+let AO_RECEIVER = process.env.AO_RECEIVER || 'U-vRZXZP3tmczr8JOW_J1wqE1KFZo3YheKF5wYBcl1Y'
 function _readConfig() {
   if (!fs.existsSync(path.join(ConfigPath, "config.yml"))) {
     fs.writeFileSync(path.join(ConfigPath, "config.yml"), '')

--- a/scripts/sub/deploy.mjs
+++ b/scripts/sub/deploy.mjs
@@ -12,7 +12,7 @@ dotenv.config()
 
 let ConfigPath = 'scripts/tmp/conf'
 let AO_MINT_PROCESS = ''
-let AO_RECEIVER = process.env.AO_RECEIVER || 'gd66FHg7Q1nMYm25lRzXuUGZv5jw5d0bKaPhHp9mkBI'
+let AO_RECEIVER = process.env.AO_RECEIVER || 'U-vRZXZP3tmczr8JOW_J1wqE1KFZo3YheKF5wYBcl1Y'
 let START_MINT_TIME = 0
 
 function _exploreNodes(node, cwd) {

--- a/scripts/sub/deploy.mjs
+++ b/scripts/sub/deploy.mjs
@@ -541,7 +541,7 @@ StartMintTime = StartMintTime or ${START_MINT_TIME}
 
 -- Log levels to control verbosity of logs
 -- Valid log levels: trace, debug, info, warn, error, fatal (default is 'info')
-LogLevel = LogLevel or 'info'
+LogLevel = LogLevel or 'trace'
 
 -- Tokenomics details for the "Apus" token
 -- The token name, ticker symbol, and logo are dynamically loaded from the config


### PR DESCRIPTION
1. Separate T0 Allocation to another file.
2. Add trace log for mint requests from cron before TGE.
3. Add handler `Metrics` for monitoring.
4. Modify mint report log.
5. Remove useless print in `token.lua`.
6. Add metrics checking in `check_after_deploy` script.
7. Set default LogLevel to `trace`.